### PR TITLE
Add Jest test for manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -137,6 +137,14 @@ Ensuring compatibility with both older and newer versions of Chrome OS could be 
 Conclusion:
 
 The Chromebook extension is a versatile tool for anyone looking to understand, maintain, and optimize their Chromebook’s performance. By offering detailed system insights, easy-to-understand documentation, and a user-friendly interface, this extension promises to be a valuable addition for Chromebook users across various fields, from education to IT support and even general consumers.
+## Running Tests
+
+Automated tests verify that the extension's `manifest.json` contains all required fields.
+
+```bash
+npm install
+npm test
+```
 
 ### Contact Us
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "chrometest",
+  "version": "1.0.0",
+  "description": "ChromeTest extension",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/tests/manifest.test.js
+++ b/tests/manifest.test.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+
+describe('manifest.json', () => {
+  test('parses and contains required fields', () => {
+    const data = fs.readFileSync('manifest.json', 'utf8');
+    const manifest = JSON.parse(data);
+    const requiredFields = [
+      'manifest_version',
+      'name',
+      'version',
+      'background',
+      'action'
+    ];
+
+    for (const field of requiredFields) {
+      expect(manifest).toHaveProperty(field);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add package.json with Jest dependency
- add a simple manifest test in `tests/`
- ignore `node_modules`
- document how to run the tests in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685671479d14832e935fc07fa22d73a9